### PR TITLE
change import of querycommand to resolve error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,7 @@ import {
     type RegisteredDatabaseSessionAttributes,
     UserId
 } from 'lucia';
-import {DeleteItemCommand, DynamoDBClient, GetItemCommand, PutItemCommand} from '@aws-sdk/client-dynamodb';
-import {QueryCommand} from '@aws-sdk/lib-dynamodb';
+import {DeleteItemCommand, DynamoDBClient, GetItemCommand, PutItemCommand, QueryCommand} from '@aws-sdk/client-dynamodb';
 import {marshall, unmarshall} from '@aws-sdk/util-dynamodb';
 
 interface DynamoDBSession {


### PR DESCRIPTION
Thank you for this library, has been quite useful!

When using the functions that depend on the getUserSessions function I got an error with the original implementation:
```
ValidationException: One or more parameter values were invalid: Condition parameter type does not match schema type
``` 

Changing the import of QueryCommand to @aws-sdk/client-dynamodb solved it. 